### PR TITLE
feat(api): 增加企业微信URL验证功能的单元测试

### DIFF
--- a/api/pytest.ini
+++ b/api/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+testpaths = tests
+# 如需默认开启覆盖率，可取消注释下一行
+# addopts = -q --cov=wecom --cov-report=term-missing
+

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,3 +1,8 @@
 fastapi==0.116.1
 uvicorn[standard]==0.35.0
 wechatpy==1.8.18
+pytest==8.4.1
+pytest-mock==3.14.1
+pytest-cov==6.2.1
+cryptography==45.0.6
+

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -1,0 +1,20 @@
+import os
+import sys
+
+
+def _ensure_api_dir_on_syspath() -> None:
+    """Ensure `api/` directory is on sys.path so `from wecom.verify` works.
+
+    Tests live in `api/tests`. Adding the parent directory (`api`) to sys.path
+    makes the `wecom` package importable as a top-level package.
+    """
+
+    tests_dir = os.path.dirname(__file__)
+    api_dir = os.path.abspath(os.path.join(tests_dir, os.pardir))
+    if api_dir not in sys.path:
+        sys.path.insert(0, api_dir)
+
+
+_ensure_api_dir_on_syspath()
+
+

--- a/api/tests/unit_tests/test_wecom_verify.py
+++ b/api/tests/unit_tests/test_wecom_verify.py
@@ -1,0 +1,56 @@
+from wecom.verify import WeComURLVerifier
+from wechatpy.exceptions import InvalidSignatureException
+
+
+def create_verifier() -> WeComURLVerifier:
+    # token / encoding_aes_key / corp_id 的值在单测中不重要，因为 check_signature 已被打桩
+    # encoding_aes_key 需要满足 43 位长度要求
+    return WeComURLVerifier(token="t", encoding_aes_key="a" * 43, corp_id="cid")
+
+
+def test_verify_url_success(mocker):
+    mock_crypto = mocker.patch("wecom.verify.WeChatCrypto")
+    mock_crypto.return_value.check_signature.return_value = "plain_echostr"
+
+    verifier = create_verifier()
+    ok, plain = verifier.verify_url(
+        msg_signature="sig",
+        timestamp="123",
+        nonce="n",
+        echostr="enc",
+    )
+
+    assert ok is True
+    assert plain == "plain_echostr"
+
+
+def test_verify_url_invalid_signature(mocker):
+    mock_crypto = mocker.patch("wecom.verify.WeChatCrypto")
+    mock_crypto.return_value.check_signature.side_effect = InvalidSignatureException("bad sig")
+
+    verifier = create_verifier()
+    ok, plain = verifier.verify_url(
+        msg_signature="sig",
+        timestamp="123",
+        nonce="n",
+        echostr="enc",
+    )
+
+    assert ok is False
+    assert plain == ""
+
+
+def test_verify_url_unexpected_error(mocker):
+    mock_crypto = mocker.patch("wecom.verify.WeChatCrypto")
+    mock_crypto.return_value.check_signature.side_effect = RuntimeError("boom")
+
+    verifier = create_verifier()
+    ok, plain = verifier.verify_url(
+        msg_signature="sig",
+        timestamp="123",
+        nonce="n",
+        echostr="enc",
+    )
+
+    assert ok is False
+    assert plain == ""

--- a/api/wecom/verify.py
+++ b/api/wecom/verify.py
@@ -45,7 +45,7 @@ class WeComURLVerifier:
         """
         try:
             plain = self.crypto.check_signature(
-                msg_signature=msg_signature,
+                signature=msg_signature,
                 timestamp=timestamp,
                 nonce=nonce,
                 echo_str=echostr,

--- a/docs/tasks/wecom_callback_reply_1.md
+++ b/docs/tasks/wecom_callback_reply_1.md
@@ -26,7 +26,7 @@ api/wecom/
 1. [x] 安装wechatpy库并研究其企业微信验证API
 2. [x] 设计验证URL的接口结构
 3. [x] 使用wechatpy实现URL验证的核心逻辑
-4. [ ] 创建测试用例验证功能正确性
+4. [x] 创建测试用例验证功能正确性（使用 pytest + pytest-mock + pytest-cov）
 5. [ ] 文档编写和部署说明
 
 ## 接口设计
@@ -57,3 +57,4 @@ api/wecom/
 - [2025-08-10] 技术方案改为使用wechatpy库，移除weworkapi_python依赖
 - [2025-08-10] 已完成wechatpy库安装和验证逻辑实现
 - [2025-08-10] 已实现WeComURLVerifier类，包含verify_url方法
+- [2025-08-10] 确定测试框架为 pytest，新增单测 `api/tests/test_wecom_verify.py`，并在 `api/requirements.txt` 补充测试依赖


### PR DESCRIPTION
- 新增 pytest 测试框架依赖 (pytest, pytest-mock, pytest-cov)
- 新增 WeComURLVerifier 类的完整单元测试用例
- 修复 wechatpy.check_signature 方法参数名错误
- 新增 pytest 配置文件和测试辅助模块

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增了针对 WeCom URL 验证功能的单元测试用例，提升了系统的可测试性和稳定性。

* **测试**
  * 引入 pytest、pytest-mock 和 pytest-cov 等测试依赖。
  * 配置了 pytest 测试环境，支持覆盖率统计。
  * 新增测试辅助配置，优化测试目录导入路径。

* **文档**
  * 更新了文档任务清单，记录测试用例和测试框架的完善情况。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->