### PR TITLE
feat(api): 添加企业微信URL验证功能

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ __pycache__/
 *.pyc
 *.pyo
 *.pyd
+
+api/.env

--- a/api/.env.example
+++ b/api/.env.example
@@ -1,0 +1,9 @@
+# 企业微信配置
+# 必填：企业微信后台设置的 Token
+WECOM_TOKEN=your_token_here
+
+# 必填：企业微信后台设置的 EncodingAESKey
+WECOM_ENCODING_AES_KEY=your_encoding_aes_key_here
+
+# 可选：企业微信 CorpID（内部机器人场景可留空）
+WECOM_CORP_ID=

--- a/api/app.py
+++ b/api/app.py
@@ -1,6 +1,11 @@
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Request, Query
+from fastapi.responses import PlainTextResponse
+from wecom.verify import WeComURLVerifier
+import os
 import uvicorn
 import logging
+from pathlib import Path
+from dotenv import load_dotenv
 
 app = FastAPI(
     title="FastAPI Demo",
@@ -13,6 +18,15 @@ logging.basicConfig(
     format="%(asctime)s %(levelname)s %(name)s: %(message)s",
 )
 logger = logging.getLogger("app.request")
+
+# 加载本地 .env 文件（位于与本文件同目录的 `.env`）
+load_dotenv(dotenv_path=Path(__file__).with_name(".env"))
+
+# 读取环境变量
+WECOM_TOKEN = os.getenv("WECOM_TOKEN")
+WECOM_ENCODING_AES_KEY = os.getenv("WECOM_ENCODING_AES_KEY")
+WECOM_CORP_ID = os.getenv("WECOM_CORP_ID", "")
+logger.info(f"token: {WECOM_TOKEN} encoding_aes_key: {WECOM_ENCODING_AES_KEY} corp_id: {WECOM_CORP_ID}")
 
 @app.get("/echo")
 async def echo_get(request: Request):
@@ -57,6 +71,56 @@ async def echo_post(request: Request):
         "query": query_params,
         "body": body_text,
     }
+
+
+@app.get("/wecom/callback")
+async def wecom_callback(
+    msg_signature: str | None = Query(default=None),
+    timestamp: str | None = Query(default=None),
+    nonce: str | None = Query(default=None),
+    echostr: str | None = Query(default=None),
+):
+    """企业微信服务器验证URL有效性
+
+    当前实现：
+    - 记录请求参数
+    - 从环境变量读取 Token/EncodingAESKey/CorpID
+    - 使用 WeComURLVerifier 验证签名并解密 echostr
+    - 验证成功返回明文 echostr，失败返回 400
+    """
+
+    logger.info(
+        "wecom_callback params: msg_signature=%s timestamp=%s nonce=%s echostr=%s",
+        msg_signature,
+        timestamp,
+        nonce,
+        echostr,
+    )
+
+    # 参数校验
+    if not all([msg_signature, timestamp, nonce, echostr]):
+        return PlainTextResponse("missing required query params", status_code=400)
+
+
+    if not WECOM_TOKEN or not WECOM_ENCODING_AES_KEY:
+        logger.error("Missing env: WECOM_TOKEN or WECOM_ENCODING_AES_KEY")
+        return PlainTextResponse("server env misconfigured", status_code=500)
+
+    # 验证签名并解密
+    try:
+        verifier = WeComURLVerifier(token=WECOM_TOKEN, encoding_aes_key=WECOM_ENCODING_AES_KEY, corp_id=WECOM_CORP_ID)
+        ok, plain = verifier.verify_url(
+            msg_signature=msg_signature,
+            timestamp=timestamp,
+            nonce=nonce,
+            echostr=echostr,
+        )
+        if not ok:
+            return PlainTextResponse("invalid signature", status_code=400)
+        return PlainTextResponse(plain)
+    except Exception as e:
+        logger.exception("wecom_callback error: %s", e)
+        return PlainTextResponse("internal error", status_code=500)
 
 if __name__ == "__main__":
     uvicorn.run("app:app", host="0.0.0.0", port=8000, reload=True)

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -5,4 +5,3 @@ pytest==8.4.1
 pytest-mock==3.14.1
 pytest-cov==6.2.1
 cryptography==45.0.6
-


### PR DESCRIPTION
- 新增 /wecom/callback 接口用于企业微信URL验证
- 添加 .env.example 模板文件用于企业微信配置
- 更新 .gitignore 忽略 .env 文件
- 集成 WeComURLVerifier 工具类进行签名验证和解密
- 添加环境变量管理支持 via python-dotenv

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增 WeCom（企业微信）服务器 URL 验证接口，支持通过 GET 请求进行签名校验与解密。
* **文档**
  * 新增环境变量示例文件，便于配置 WeCom 所需参数。
* **杂项**
  * 更新 .gitignore，忽略敏感环境变量文件。
  * 清理依赖文件中的多余空行。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->