### PR TITLE
feat(api): 实现企业微信JSON回调加密回复功能

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -171,10 +171,18 @@ async def wecom_callback_post(
         # }
         logger.info("wecom_callback_post decrypted plain xml: %s", plain_xml)
 
-        # 构造固定文本“收到”的被动回复（明文需为字符串）
+        # 直接使用随机 UUID 作为流式消息 id
+        import uuid
+        stream_id = uuid.uuid4().hex
+
+        # 构造“回复用户消息”的流式消息（明文需为字符串）
         reply_plain_json = {
-            "msgtype": "text",
-            "text": {"content": "收到"},
+            "msgtype": "stream",
+            "stream": {
+                "id": stream_id,
+                "finish": True,
+                "content": "收到",
+            },
         }
         reply_plain_text = json.dumps(reply_plain_json, ensure_ascii=False)
 

--- a/api/tests/integration_tests/test_wecom_crypto_integration.py
+++ b/api/tests/integration_tests/test_wecom_crypto_integration.py
@@ -1,6 +1,5 @@
 from wecom import WeComMessageCrypto
-from wechatpy.enterprise.crypto import WeChatCrypto
-import xml.etree.ElementTree as ET
+import json
 
 
 # 使用用户提供的配置（与 verify 集成测试保持一致）
@@ -11,34 +10,28 @@ CORP_ID = ""
 
 
 def test_decrypt_from_json_success_integration():
-    crypto_sdk = WeChatCrypto(TOKEN, AES_KEY, CORP_ID)
-
-    # 固定时间戳与随机串，保证结果可复现
+    # 固定随机串，timestamp 由底层生成
     nonce = "1754668868"
-    timestamp = "1754796900"
 
-    # 待加密的明文（POST 解密后应返回该明文）
-    plain_xml = "<xml><FromUserName><![CDATA[u]]></FromUserName><ToUserName><![CDATA[v]]></ToUserName><MsgType><![CDATA[text]]></MsgType><Content><![CDATA[hi]]></Content></xml>"
-    # 使用 wechatpy 生成一组有效的密文与签名（与 URL 验证不同，这里我们只取 Encrypt，然后自己签名）
-    encrypted_xml = crypto_sdk.encrypt_message(plain_xml, nonce, timestamp)
-
-    # 解析出 Encrypt
-    root = ET.fromstring(encrypted_xml)
-    encrypt = root.findtext("Encrypt")
-
-    # wechatpy 的 check_signature/ decrypt_message 在 decrypt_message 内部会做签名校验
-    # 因此对调用方来说，准备 msg_signature/timestamp/nonce 即可
-    # 这里直接复用集成加密过程得到的 MsgSignature/TimeStamp/Nonce
-    msg_signature = root.findtext("MsgSignature")
-    ts = root.findtext("TimeStamp")
-    n = root.findtext("Nonce")
+    # 待加密的明文（JSON 字符串），解密应还原为同一 JSON 结构
+    plain_obj = {
+        "msgtype": "text",
+        "text": {"content": "hi"},
+    }
+    plain_text = json.dumps(plain_obj, ensure_ascii=False)
 
     crypto = WeComMessageCrypto(token=TOKEN, encoding_aes_key=AES_KEY, corp_id=CORP_ID)
-    plain = crypto.decrypt_from_json(
-        msg_signature=msg_signature,
-        timestamp=ts,
-        nonce=n,
-        body={"encrypt": encrypt},
+
+    # 使用 WeComMessageCrypto 加密（返回包含 encrypt/msgsignature/timestamp/nonce 的 JSON 字段）
+    enc = crypto.encrypt_to_json(plain_text=plain_text, nonce=nonce)
+
+    # 用返回的签名/时间戳/随机串/密文调用解密
+    decrypted_text = crypto.decrypt_from_json(
+        msg_signature=enc["msgsignature"],
+        timestamp=str(enc["timestamp"]),
+        nonce=enc["nonce"],
+        body={"encrypt": enc["encrypt"]},
     )
 
-    assert plain == plain_xml
+    # 解析为对象对比结构等价，避免字符串序列化差异影响
+    assert json.loads(decrypted_text) == plain_obj

--- a/api/tests/unit_tests/test_wecom_crypto.py
+++ b/api/tests/unit_tests/test_wecom_crypto.py
@@ -55,3 +55,26 @@ def test_decrypt_from_json_missing_encrypt():
         )
 
 
+def test_encrypt_to_json_success(mocker):
+    mock_crypto_cls = mocker.patch("wecom.crypto.WeChatCrypto")
+    # wechatpy.encrypt_message 返回的 XML，包含四个关键字段
+    mock_crypto_cls.return_value.encrypt_message.return_value = (
+        "<xml>"
+        "<Encrypt><![CDATA[cipher_text]]></Encrypt>"
+        "<MsgSignature><![CDATA[msg_sig]]></MsgSignature>"
+        "<TimeStamp>1754796900</TimeStamp>"
+        "<Nonce><![CDATA[noncev]]></Nonce>"
+        "</xml>"
+    )
+
+    crypto = create_crypto()
+    result = crypto.encrypt_to_json(
+        plain_text="<xml>plain</xml>",
+        nonce="noncev",
+    )
+
+    assert result["encrypt"] == "cipher_text"
+    assert result["msgsignature"] == "msg_sig"
+    # timestamp 字段应为固定值（来自打桩返回）
+    assert result["timestamp"] == 1754796900
+    assert result["nonce"] == "noncev"


### PR DESCRIPTION
- 新增 WeComMessageCrypto.encrypt_to_json 方法，支持JSON格式加密回复
- 优化 /wecom/callback POST接口，解密后自动回复收到
- 完善单元测试和集成测试，确保加密解密流程正确性
- 支持企业内部智能机器人场景的空ReceiveId处理

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新功能
  - 企业微信回调支持JSON加密通道；成功时返回加密JSON，被动回复“收到”文本。
- 行为变更
  - 回调成功响应由原先的元数据/XML改为加密JSON；签名校验与错误码行为保持不变（签名错误400，其他失败500）。
- 测试
  - 新增并更新单元与集成测试，覆盖JSON加解密与回调流程，提升稳定性与正确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->