### PR TITLE
refactor(api): 简化企业微信解密API接口

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -137,9 +137,6 @@ async def wecom_callback_post(
 ):
     """企业微信回调 POST（新回调 JSON 模式：解密并被动回复“收到”）。"""
 
-    headers = dict(request.headers)
-    query_params = {"msg_signature": msg_signature, "timestamp": timestamp, "nonce": nonce}
-
     # 读取 JSON 请求体并直接取 encrypt（签名中声明为 dict，无需再判断类型）
     encrypt = body.get("encrypt")
     if not isinstance(encrypt, str) or not encrypt:
@@ -158,7 +155,7 @@ async def wecom_callback_post(
             msg_signature=msg_signature,
             timestamp=str(timestamp),
             nonce=str(nonce),
-            body={"encrypt": encrypt},
+            encrypt=encrypt,
         )
         # 解密出来的消息，实际是 JSON 格式，例如：
         # {

--- a/api/tests/integration_tests/test_wecom_crypto_integration.py
+++ b/api/tests/integration_tests/test_wecom_crypto_integration.py
@@ -30,7 +30,7 @@ def test_decrypt_from_json_success_integration():
         msg_signature=enc["msgsignature"],
         timestamp=str(enc["timestamp"]),
         nonce=enc["nonce"],
-        body={"encrypt": enc["encrypt"]},
+        encrypt=enc["encrypt"],
     )
 
     # 解析为对象对比结构等价，避免字符串序列化差异影响

--- a/api/tests/unit_tests/test_wecom_crypto.py
+++ b/api/tests/unit_tests/test_wecom_crypto.py
@@ -18,7 +18,7 @@ def test_decrypt_from_json_success(mocker):
         msg_signature="sig",
         timestamp="123",
         nonce="n",
-        body={"encrypt": "ENC"},
+        encrypt="ENC",
     )
 
     assert plain == "<xml>plain</xml>"
@@ -40,7 +40,7 @@ def test_decrypt_from_json_invalid_signature(mocker):
             msg_signature="sig",
             timestamp="123",
             nonce="n",
-            body={"encrypt": "ENC"},
+            encrypt="ENC",
         )
 
 
@@ -51,7 +51,7 @@ def test_decrypt_from_json_missing_encrypt():
             msg_signature="sig",
             timestamp="123",
             nonce="n",
-            body={},
+            encrypt="",
         )
 
 


### PR DESCRIPTION
- 移除_wecom/crypto.py_中冗余的_ensure_encrypt_from_body方法
- 简化decrypt_from_json方法签名，直接接受encrypt参数
- 更新api/app.py中调用方式，移除未使用的变量
- 同步更新所有相关测试用例

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新功能
  - 无
- Bug Fixes
  - 加强输入校验：对空或无效的加密内容返回更明确的错误提示；响应状态码行为保持不变（签名错误400，其他错误500）。
- Refactor
  - 简化解密流程并移除冗余处理，提升稳定性与可维护性；不影响现有接口的对外行为。
- Tests
  - 更新集成与单元测试以覆盖新的校验路径，确保解密与签名验证流程稳定。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->