### PR TITLE
ci: 优化Claude代码审查工作流的git历史获取

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Run Claude Code Review
         id: claude-review


### PR DESCRIPTION
将fetch-depth从1改为0，确保获取完整的git历史记录，这对于代码审查工作流更加合适。