### PR TITLE
feat(api): 完善Docker容器化配置，添加Nginx反向代理和API前缀路由

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -11,6 +11,9 @@ WECOM_CORP_ID=
 
 LOG_LEVEL=INFO
 
+# 运行环境：dev | prod（默认 dev）
+APP_ENV=dev
+
 # OpenAI（可选）
 # 若需要使用真实 LLM 流式回复，请配置以下变量
 # API Key（必填以启用真实流式）

--- a/api/app.py
+++ b/api/app.py
@@ -7,7 +7,17 @@ from utils import register_exception_handlers
 from utils.config import settings
 from utils.logging import get_logger, init_logging
 
-app = FastAPI(title="FastAPI Demo", description="A simple FastAPI application", version="1.0.0")
+API_PREFIX = "/api"
+ENABLE_DOCS = settings.APP_ENV != "prod"
+
+app = FastAPI(
+    title="FastAPI Demo",
+    description="A simple FastAPI application",
+    version="1.0.0",
+    docs_url=f"{API_PREFIX}/docs" if ENABLE_DOCS else None,
+    redoc_url=f"{API_PREFIX}/redoc" if ENABLE_DOCS else None,
+    openapi_url=f"{API_PREFIX}/openapi.json" if ENABLE_DOCS else None,
+)
 
 init_logging(settings.LOG_LEVEL)
 logger = get_logger()
@@ -20,8 +30,8 @@ register_exception_handlers(app)
 
 # 挂载路由（echo、wecom callback 等）
 
-app.include_router(echo_router)
-app.include_router(wecom_router)
+app.include_router(echo_router, prefix=API_PREFIX)
+app.include_router(wecom_router, prefix=API_PREFIX)
 
 # 记录配置信息用于调试
 logger.info(

--- a/api/bin/boot.sh
+++ b/api/bin/boot.sh
@@ -4,8 +4,6 @@ set -euo pipefail
 HOST=${HOST:-"0.0.0.0"}
 PORT=${PORT:-8000}
 WORKERS=${WORKERS:-1}
-API_PATH=${API_PATH:-"/api"}
 
-cd "$API_PATH"
 echo "fastapi run on $HOST:$PORT with $WORKERS workers"
 exec uvicorn app:app --host "$HOST" --port "$PORT" --workers "$WORKERS"

--- a/api/utils/config.py
+++ b/api/utils/config.py
@@ -19,6 +19,9 @@ class Settings:
             env_path = Path(__file__).with_name("..").resolve().joinpath(".env.example")
         load_dotenv(dotenv_path=env_path)
 
+        # 基础运行环境
+        self.APP_ENV: str = os.getenv("APP_ENV", "dev").lower()
+
         self.WECOM_TOKEN: str | None = os.getenv("WECOM_TOKEN")
         self.WECOM_ENCODING_AES_KEY: str | None = os.getenv("WECOM_ENCODING_AES_KEY")
         self.WECOM_CORP_ID: str = os.getenv("WECOM_CORP_ID", "")

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,0 +1,25 @@
+# docker-compose.yaml
+
+services:
+  api:
+    image: api:latest
+    container_name: api
+    # ports:
+    #   - "8000:8000"
+    environment:
+      - HOST=0.0.0.0
+      - PORT=8000
+      - WORKERS=1
+    restart: always
+
+  nginx:
+    image: nginx:latest
+    container_name: gateway
+    ports:
+      - "80:80"
+    volumes:
+      - ./volume/nginx/nginx.conf:/etc/nginx/nginx.conf
+      - ./volume/nginx/conf.d:/etc/nginx/conf.d
+    depends_on:
+      - api
+    restart: always

--- a/docker/volume/nginx/conf.d/default.conf
+++ b/docker/volume/nginx/conf.d/default.conf
@@ -1,0 +1,21 @@
+server {
+    listen 80;
+    server_name localhost;
+
+    proxy_buffering off;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+
+    # WebSocket支持
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+
+
+    # API接口
+    location /api/ {
+        proxy_pass http://api:8000;
+    }
+}

--- a/docker/volume/nginx/nginx.conf
+++ b/docker/volume/nginx/nginx.conf
@@ -1,0 +1,24 @@
+user nginx;
+worker_processes auto;
+error_log /var/log/nginx/error.log warn;
+pid /var/run/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log /var/log/nginx/access.log main;
+
+    sendfile on;
+    keepalive_timeout 65;
+
+    include /etc/nginx/conf.d/*.conf;
+}


### PR DESCRIPTION
## Summary
- 完善Docker容器化配置，添加Nginx反向代理支持
- 优化API路由结构，统一使用/api前缀
- 新增APP_ENV环境变量配置，支持区分开发/生产环境
- 根据环境自动开关API文档页面
- 完善docker-compose配置，包含API和Nginx服务

## Test plan
- [ ] 本地Docker环境测试通过
- [ ] API文档页面在dev环境正常显示
- [ ] 生产环境自动隐藏API文档
- [ ] Nginx反向代理配置正确

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 新功能
  * 统一 API 前缀为 /api。
  * 非生产环境启用在线文档（/api/docs、/api/redoc、/api/openapi.json）；生产环境关闭。
* 杂务
  * 新增 Docker Compose 与 Nginx 反向代理，默认暴露 80 端口并将 /api 转发至后端服务。
  * 新增环境变量 APP_ENV（dev|prod，默认 dev）。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->