### PR TITLE
ci(docker): fix build-push workflow by removing redundant web filter

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      
+
       - name: Check for file changes
         uses: dorny/paths-filter@v3
         id: filter
@@ -30,7 +30,6 @@ jobs:
           filters: |
             api:
               - 'api/**'
-            web:
             workflow:
               - '.github/workflows/**'
 


### PR DESCRIPTION
## Summary
Fixed the build-push workflow by removing a redundant `web` filter that was defined without any path patterns, which could cause workflow validation issues.

## Changes
- Removed the empty `web:` filter from the path filters configuration
- Fixed whitespace and end-of-file formatting issues via pre-commit hooks

## Test plan
- [x] Pre-commit hooks passed successfully
- [x] Workflow file is syntactically valid
- [x] Branch pushed to remote repository

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>