### PR TITLE
ci(docker): 更新部署配置 - 使用阿里云镜像仓库和端口映射调整

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -2,14 +2,14 @@
 
 services:
   api:
-    image: api:latest
+    image: registry.cn-hangzhou.aliyuncs.com/hanfangyuan/api:main
     container_name: api
-    # ports:
-    #   - "8000:8000"
     environment:
       - HOST=0.0.0.0
       - PORT=8000
       - WORKERS=1
+    volumes:
+      - .env:/api/.env
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/api/health"]
       interval: 30s
@@ -22,7 +22,7 @@ services:
     image: nginx:latest
     container_name: gateway
     ports:
-      - "80:80"
+      - "8000:80"
     volumes:
       - ./volume/nginx/nginx.conf:/etc/nginx/nginx.conf
       - ./volume/nginx/conf.d:/etc/nginx/conf.d


### PR DESCRIPTION
## Summary
- 更新API镜像为阿里云容器镜像仓库地址 
- 添加.env文件卷挂载配置，便于环境变量管理
- 调整nginx端口映射为8000:80，避免与系统80端口冲突

## Test plan
- [x] 验证docker-compose配置语法正确性
- [x] 确保端口映射不会与现有服务冲突
- [x] 验证阿里云镜像仓库地址格式正确

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - 网关服务对外端口由80调整为8000，默认访问地址需相应变更（如：http://localhost:8000）。
  - 增强健康检查（超时、重试、启动等待）并启用自动重启策略，提升服务稳定性与可用性。
  - 切换后端镜像来源，优化镜像获取与发布一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->