### PR TITLE
fix(ci): update issue triage workflow configuration

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -21,57 +21,28 @@ jobs:
       - name: Triage issue with Claude
         uses: anthropics/claude-code-action@v1
         env:
-          ANTHROPIC_BASE_URL: https://api.moonshot.cn/anthropic/
-          # ANTHROPIC_BASE_URL: https://open.bigmodel.cn/api/anthropic
+          # ANTHROPIC_BASE_URL: https://api.moonshot.cn/anthropic/
+          ANTHROPIC_BASE_URL: https://open.bigmodel.cn/api/anthropic
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          # anthropic_api_key: ${{ secrets.GLM_API_KEY }
+          # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.GLM_API_KEY }
           prompt: |
-            You're an issue triage assistant for GitHub issues. Your task is to analyze the issue and select appropriate labels from the provided list.
+            REPO: ${{ github.repository }}
+            ISSUE NUMBER: ${{ github.event.issue.number }}
+            TITLE: ${{ github.event.issue.title }}
+            BODY: ${{ github.event.issue.body }}
+            AUTHOR: ${{ github.event.issue.user.login }}
 
-            IMPORTANT: Don't post any comments or messages to the issue. Your only action should be to apply labels.
+            Analyze this new issue and:
+            1. Determine if it's a bug report, feature request, or question
+            2. Assess priority (critical, high, medium, low)
+            3. Suggest appropriate labels
+            4. Check if it duplicates existing issues
 
-            Issue Information:
-            - REPO: ${{ github.repository }}
-            - ISSUE_NUMBER: ${{ github.event.issue.number }}
+            Based on your analysis, add the appropriate labels using:
+            `gh issue edit [number] --add-label "label1,label2"`
 
-            TASK OVERVIEW:
+            If it appears to be a duplicate, post a comment mentioning the original issue.
 
-            1. First, fetch the list of labels available in this repository by running: `gh label list`. Run exactly this command with nothing else.
-
-            2. Next, use the GitHub tools to get context about the issue:
-               - You have access to these tools:
-                 - mcp__github__get_issue: Use this to retrieve the current issue's details including title, description, and existing labels
-                 - mcp__github__get_issue_comments: Use this to read any discussion or additional context provided in the comments
-                 - mcp__github__update_issue: Use this to apply labels to the issue (do not use this for commenting)
-                 - mcp__github__search_issues: Use this to find similar issues that might provide context for proper categorization and to identify potential duplicate issues
-                 - mcp__github__list_issues: Use this to understand patterns in how other issues are labeled
-               - Start by using mcp__github__get_issue to get the issue details
-
-            3. Analyze the issue content, considering:
-               - The issue title and description
-               - The type of issue (bug report, feature request, question, etc.)
-               - Technical areas mentioned
-               - Severity or priority indicators
-               - User impact
-               - Components affected
-
-            4. Select appropriate labels from the available labels list provided above:
-               - Choose labels that accurately reflect the issue's nature
-               - Be specific but comprehensive
-               - Select priority labels if you can determine urgency (high-priority, med-priority, or low-priority)
-               - Consider platform labels (android, ios) if applicable
-               - If you find similar issues using mcp__github__search_issues, consider using a "duplicate" label if appropriate. Only do so if the issue is a duplicate of another OPEN issue.
-
-            5. Apply the selected labels:
-               - Use mcp__github__update_issue to apply your selected labels
-               - DO NOT post any comments explaining your decision
-               - DO NOT communicate directly with users
-               - If no labels are clearly applicable, do not apply any labels
-
-            IMPORTANT GUIDELINES:
-            - Be thorough in your analysis
-            - Only select labels from the provided list above
-            - DO NOT post any comments to the issue
-            - Your ONLY action should be to apply labels using mcp__github__update_issue
-            - It's okay to not add any labels if none are clearly applicable
+          claude_args: |
+            --allowedTools "Bash(gh issue:*),Bash(gh search:*)"


### PR DESCRIPTION
## Summary
- Switch API endpoint from moonshot.cn to open.bigmodel.cn
- Update API key from ANTHROPIC_API_KEY to GLM_API_KEY  
- Simplify prompt structure and add claude_args for allowed tools

## Test plan
- [ ] Verify workflow runs successfully
- [ ] Check that issue triage works with new API configuration
- [ ] Ensure proper permissions for GitHub API calls

🤖 Generated with [Claude Code](https://claude.ai/code)