### PR TITLE
ci(.github): Add label tools to issue triage workflow

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -45,4 +45,4 @@ jobs:
             If it appears to be a duplicate, post a comment mentioning the original issue.
 
           claude_args: |
-            --allowedTools "Bash(gh issue:*),Bash(gh search:*)"
+            --allowedTools "Bash(gh issue:*),Bash(gh search:*),Bash(gh label:*)"


### PR DESCRIPTION
## Summary
- Add `Bash(gh label:*)` to allowed tools in issue triage workflow
- Enables Claude to manage GitHub labels during issue triage

## Test plan
- [ ] Verify the workflow runs successfully
- [ ] Test label management functionality

🤖 Generated with [Claude Code](https://claude.ai/code)