### PR TITLE
fix(github): revert Claude workflows to use ANTHROPIC_API_KEY instead of GLM_API_KEY

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -34,11 +34,10 @@ jobs:
         id: claude-review
         uses: anthropics/claude-code-action@v1
         env:
-          # ANTHROPIC_BASE_URL: https://api.moonshot.cn/anthropic/
+          # ANTHROPIC_BASE_URL: https://api.moonshot.cn/anthropic
           ANTHROPIC_BASE_URL: https://open.bigmodel.cn/api/anthropic
         with:
-          # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          anthropic_api_key: ${{ secrets.GLM_API_KEY }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
           prompt: |
             REPO: ${{ github.repository }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -37,7 +37,6 @@ jobs:
           # ANTHROPIC_BASE_URL: https://api.moonshot.cn/anthropic
           ANTHROPIC_BASE_URL: https://open.bigmodel.cn/api/anthropic
         with:
-          # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          anthropic_api_key: ${{ secrets.GLM_API_KEY }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh issue:*),Bash(gh search:*),Bash(gh label:*)"

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -21,11 +21,10 @@ jobs:
       - name: Triage issue with Claude
         uses: anthropics/claude-code-action@v1
         env:
-          # ANTHROPIC_BASE_URL: https://api.moonshot.cn/anthropic/
+          # ANTHROPIC_BASE_URL: https://api.moonshot.cn/anthropic
           ANTHROPIC_BASE_URL: https://open.bigmodel.cn/api/anthropic
         with:
-          # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          anthropic_api_key: ${{ secrets.GLM_API_KEY }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |
             REPO: ${{ github.repository }}
             ISSUE NUMBER: ${{ github.event.issue.number }}


### PR DESCRIPTION
## Summary
- Revert Claude workflows to use ANTHROPIC_API_KEY instead of GLM_API_KEY
- Clean up commented API key configurations in workflow files
- Ensures proper authentication for Claude Code actions

## Files Changed
- `.github/workflows/claude-review.yml`
- `.github/workflows/claude.yml`
- `.github/workflows/issue-triage.yml`

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新增/变更无

- Bug Fixes 无

- Documentation
  - 更新示例配置注释，去除基础地址尾随斜杠，提升一致性与可读性。

- Chores
  - 持续集成相关工作流改用统一的 ANTHROPIC_API_KEY，移除旧密钥引用；评审、代码与问题分拣流程均已同步调整。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->