### PR TITLE
chore(github): add manual trigger to issue triage workflow

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,7 +1,8 @@
 name: Issue Triage
 on:
-  issues:
-    types: [opened]
+  # issues:
+  #   types: [opened]
+  workflow_dispatch:
 
 jobs:
   triage-issue:


### PR DESCRIPTION
## Summary
- Add manual trigger capability to issue triage workflow
- Comment out automatic issue trigger to prevent unintended execution
- Enable manual workflow execution for better control

## Test plan
- Verify workflow can be triggered manually from GitHub Actions UI
- Ensure automatic issue trigger is disabled

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 将问题分拣工作流由“新建问题自动触发”调整为“手动触发”，原有流程逻辑保持不变。
  * 停用新问题的自动分拣，需在需要时由维护者手动运行工作流。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->