### PR TITLE
fix: replace curl with Python-based health check in Docker Compose

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -11,7 +11,7 @@ services:
     volumes:
       - .env:/api/.env
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/api/health"]
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/health')"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -11,7 +11,7 @@ services:
     volumes:
       - .env:/api/.env
     healthcheck:
-      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/health')"]
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/api/health', timeout=10).read()"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
Fixes Docker Compose startup issue by replacing curl-based health check with Python-based approach.

## Problem
The health check command `["CMD", "curl", "-f", "http://localhost:8000/api/health"]` was failing because curl was not installed in the Python slim image.

## Solution
Replaced the health check with a Python-based approach using urllib.request from the standard library:
```yaml
test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/health')"]
```

This eliminates the dependency on curl and uses only Python's standard library which is available in the container.

Fixes #77

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 杂项
  - 改进容器健康检查实现，提升在不同运行环境下的可靠性与可观测性；健康检查频率与超时等参数保持不变，对业务功能无影响；有助于更快发现异常并减少误报。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->